### PR TITLE
Use https to fetch submodules, not ssh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/jrnold/CDB90
 [submodule "dependencies/cwss"]
 	path = dependencies/cwss
-	url = git@github.com:jrnold/cwss.git
+	url = https://github.com/jrnold/cwss.git
 [submodule "dependencies/PAR"]
 	path = dependencies/PAR
-	url = git@github.com:jrnold/PAR.git
+	url = https://github.com/jrnold/PAR.git


### PR DESCRIPTION
Allows users without relevant private ssh key to access submodules.
